### PR TITLE
Add Playwright test for homepage verification

### DIFF
--- a/e2e/tests/homepage.spec.ts
+++ b/e2e/tests/homepage.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test';
+
+test('homepage has title and links', async ({ page }) => {
+  await page.goto('https://example.com');
+  await expect(page).toHaveTitle(/Example Domain/);
+  const link = page.locator('a');
+  await expect(link).toHaveAttribute('href', 'https://www.iana.org/domains/example');
+});


### PR DESCRIPTION
Added Playwright smoke test under e2e/tests/homepage.spec.ts to verify that the homepage loads successfully and contains the expected title and link.

This serves as the base structure for upcoming smoke tests (hero, contact, donate, about).
