### PR TITLE
Add flake8 lint workflow for Python files on PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,25 @@
+name: Lint Python Files
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install flake8
+        run: pip install flake8
+
+      - name: Run flake8
+        run: flake8 . --count --max-line-length=120 --statistics

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+    types: [opened, synchronize, reopened]
 
 jobs:
   lint:
@@ -22,4 +23,9 @@ jobs:
         run: pip install flake8
 
       - name: Run flake8
-        run: flake8 . --count --max-line-length=120 --statistics
+        run: |
+          flake8 . \
+            --count \
+            --max-line-length=120 \
+            --exclude=.git,__pycache__,*.egg-info \
+            --statistics

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,10 +22,5 @@ jobs:
       - name: Install flake8
         run: pip install flake8
 
-      - name: Run flake8
-        run: |
-          flake8 . \
-            --count \
-            --max-line-length=120 \
-            --exclude=.git,__pycache__,*.egg-info \
-            --statistics
+      - - name: Run flake8
+        run: flake8 . --count --max-line-length=120 --exclude=.git,__pycache__,*.egg-info --statistics


### PR DESCRIPTION
Closes #90

Added a GitHub Actions workflow that runs flake8 on all Python files 
whenever a pull request is opened against main. Helps catch formatting 
and syntax issues early in the review process.